### PR TITLE
Optimized like endpoint in backend

### DIFF
--- a/src/_reducers/post.js
+++ b/src/_reducers/post.js
@@ -16,7 +16,23 @@ export default (state = { all: [], single: null }, action) => {
 		case 'POST/EDIT_ALL':
 			return { ...state }
 		case 'POST/LIKE_SINGLE':
-			return { ...state, single: { ...state.single, likes: action.payload } }
+			return {
+				...state,
+				single: {
+					...state.single,
+					likes: [...state.single.likes, action.payload],
+				},
+			}
+		case 'POST/LIKE_SINGLE/REMOVE':
+			// remove the given user _id (action payload) from likes
+			return {
+				...state,
+				single: {
+					...state.single,
+					likes: state.single.likes.map((userId) => userId !== action.payload),
+				},
+			}
+
 		default:
 			return state
 	}

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -124,11 +124,17 @@ const Recipe = ({ id }) => {
 							<Button
 								onClick={async () => {
 									const result = await likePost(post._id)
-									console.log(result)
-									dispatch({
-										type: 'POST/LIKE_SINGLE',
-										payload: result.post.likes,
-									})
+									if (result.result !== 0) {
+										dispatch({
+											type: 'POST/LIKE_SINGLE',
+											payload: result.result,
+										})
+									} else {
+										dispatch({
+											type: 'POST/LIKE_SINGLE/REMOVE',
+											payload: user._id,
+										})
+									}
 								}}
 								type={post.likes.includes(user._id) ? 'liked' : 'like'}
 							/>


### PR DESCRIPTION
Alter code to reflect changes to backend. Instead of sending 'likes' array, which can get large, send 0 or 1 representing if the post was liked by the user or not